### PR TITLE
infra初期導入: Terraform雛形を追加（hotel-de-workから移植、state類除外・tfvarsはexample化）

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -1,0 +1,77 @@
+#########################################
+# ALB (Application Load Balancer) 定義
+#########################################
+
+resource "aws_lb" "web_admin" {
+  name               = "hotel-de-work-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb_sg.id]
+  subnets = [
+    aws_subnet.public_a.id,
+    aws_subnet.public_b.id
+  ]
+
+  enable_http2 = true
+  idle_timeout = 60
+}
+
+#########################################
+# ターゲットグループ（ポート8080でFargateのRailsをターゲットに）
+#########################################
+
+resource "aws_lb_target_group" "web_admin" {
+  name        = "web-admin-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip" # Fargateでは"ip"指定が必要
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  health_check {
+    path                = "/healthcheck"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    matcher             = "200-399"
+  }
+
+  load_balancing_algorithm_type = "round_robin"
+}
+
+#########################################
+# HTTP リスナー（ポート80 → Railsへフォワード）
+#########################################
+
+resource "aws_lb_listener" "web_admin" {
+  load_balancer_arn = aws_lb.web_admin.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.web_admin.arn
+  }
+}
+
+#########################################
+# HTTPS リスナー（ポート443 → Railsへフォワード）
+# ※ fixed_response を削除し、正しくforwardへ
+#########################################
+
+resource "aws_lb_listener" "web_admin_https" {
+  load_balancer_arn = aws_lb.web_admin.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = "arn:aws:acm:ap-northeast-1:572902360514:certificate/406aff7f-8ab5-4c36-83c2-9826b600908a"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.web_admin.arn
+  }
+}

--- a/infra/alb_target_group.tf
+++ b/infra/alb_target_group.tf
@@ -1,0 +1,18 @@
+resource "aws_lb_target_group" "web_admin_tg" {
+  name     = "web-admin-tg"
+  port     = 8080
+  protocol = "HTTP"
+  target_type = "ip"
+  vpc_id = aws_vpc.main.id
+
+  health_check {
+    path                = "/healthcheck"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    port                = "traffic-port"
+  }
+}

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "web_admin" {
+  name              = "/ecs/hotel-de-work-web-admin"
+  retention_in_days = 14
+}

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,39 @@
+resource "aws_ecr_repository" "hotel_de_work" {
+  name                 = "hotel-de-work"
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+resource "aws_ecr_repository_policy" "allow_push_by_admin" {
+  repository = aws_ecr_repository.hotel_de_work.name
+
+  policy = jsonencode({
+    Version = "2008-10-17",
+    Statement = [
+      {
+        Sid    = "AllowPushByHotelDeWorkAdmin",
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::572902360514:user/hotel-de-work-admin"
+        },
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "allow_push" {
+  user       = "hotel-de-work-admin"
+  policy_arn = aws_iam_policy.ecr_push_policy.arn
+}

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -1,0 +1,4 @@
+resource "aws_ecs_cluster" "web_admin_cluster" {
+  name = "${var.project_name}-${var.environment}-cluster"
+}
+

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,67 @@
+###############################
+# ECSタスク実行ロール（ECS用）
+###############################
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# ECSの基本実行ポリシー（イメージPull、Secrets参照など）
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# ECS Exec（SSMによるリモートアクセス）用の追加ポリシー
+resource "aws_iam_role_policy_attachment" "ecs_exec_ssm" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+##################################
+# ECR Push用カスタムポリシー
+##################################
+resource "aws_iam_policy" "ecr_push_policy" {
+  name        = "AllowECRPushToHotelDeWork"
+  description = "Allow pushing Docker images to hotel-de-work ECR repository"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ],
+        Resource = "arn:aws:ecr:ap-northeast-1:123456789012:repository/hotel-de-work"
+      }
+    ]
+  })
+}
+
+##################################
+# IAMユーザー（docker push用）
+# hotel-de-work-admin への権限付与
+##################################
+resource "aws_iam_user_policy_attachment" "ecr_push_permission_to_user" {
+  user       = "hotel-de-work-admin"
+  policy_arn = aws_iam_policy.ecr_push_policy.arn
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}

--- a/infra/network.tf
+++ b/infra/network.tf
@@ -1,0 +1,43 @@
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_b" {
+  subnet_id      = aws_subnet.public_b.id
+  route_table_id = aws_route_table.public.id
+}
+

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_dns_name" {
+  value = aws_lb.web_admin.dns_name
+}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,27 @@
+resource "aws_db_subnet_group" "web_admin" {
+  name       = "web-admin-db-subnet-group"
+  subnet_ids = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+
+  tags = {
+    Name = "web-admin-db-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "web_admin" {
+  identifier             = "hotel-de-work-db"
+  engine                 = "mysql"
+  engine_version         = "8.0"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  db_name                = "hotelworkdb"
+  username               = "admin"
+  password               = "adminpassword123"
+  skip_final_snapshot    = true
+  publicly_accessible    = true
+  db_subnet_group_name   = aws_db_subnet_group.web_admin.name
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+
+  tags = {
+    Name = "hotel-de-work-db"
+  }
+}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1,0 +1,84 @@
+# ============================
+# ALB用のセキュリティグループ
+# ============================
+
+resource "aws_security_group" "alb_sg" {
+  name        = "alb-sg"
+  description = "Allow HTTP access to ALB" # ✅ 差分ゼロにするため、元の文言に戻す
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# =================================
+# ECSタスク（web-admin）用セキュリティグループ
+# =================================
+
+resource "aws_security_group" "web_admin_sg" {
+  name        = "web-admin-sg"
+  description = "Allow traffic from ALB to ECS tasks" # ✅ 元の文言に戻す
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+# =================================
+# RDS（MySQL）用セキュリティグループ
+# =================================
+resource "aws_security_group" "rds_sg" {
+  name        = "rds-sg"
+  description = "Security group for RDS MySQL access"
+  vpc_id      = aws_vpc.main.id
+
+  # RDSから外部への通信（例：DNS解決や時刻同期など）は全許可
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # インバウンドは下で `aws_security_group_rule` として別定義
+}
+# ===============================
+# Allow ECS Tasks to connect to RDS
+# ===============================
+resource "aws_security_group_rule" "allow_web_admin_to_rds" {
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.rds_sg.id
+  source_security_group_id = aws_security_group.web_admin_sg.id
+  description              = "Allow web-admin ECS tasks to access RDS MySQL"
+}

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -1,0 +1,23 @@
+resource "aws_ecs_service" "web_admin" {
+  name            = "web-admin-service"
+  cluster         = aws_ecs_cluster.web_admin_cluster.id
+  task_definition = aws_ecs_task_definition.web_admin.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  enable_execute_command = true # ✅ これを追加
+
+  network_configuration {
+    subnets          = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+    security_groups  = [aws_security_group.web_admin_sg.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.web_admin.arn
+    container_name   = "web-admin"
+    container_port   = 8080
+  }
+
+  depends_on = [aws_lb_listener.web_admin]
+}

--- a/infra/task_definition.tf
+++ b/infra/task_definition.tf
@@ -1,0 +1,75 @@
+resource "aws_ecs_task_definition" "web_admin" {
+  family                   = "hotel-de-work-web-admin"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_execution_role.arn
+
+  # ✅ Execute Commandを有効化（必要に応じてコメント解除）
+  # enable_execute_command = true
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "web-admin",
+      image     = "572902360514.dkr.ecr.ap-northeast-1.amazonaws.com/hotel-de-work-web-admin:latest",
+      essential = true,
+      portMappings = [
+        {
+          containerPort = 8080,
+          hostPort      = 8080,
+          protocol      = "tcp"
+        }
+      ],
+      command = ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "8080"],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          awslogs-group         = "/ecs/hotel-de-work-web-admin",
+          awslogs-region        = "ap-northeast-1",
+          awslogs-stream-prefix = "web-admin"
+        }
+      },
+      environment = [
+        {
+          name  = "FORCE_UPDATE"
+          value = "2025-07-24T13:53:00Z"
+        },
+        {
+          name  = "SECRET_KEY_BASE"
+          value = "3e3edf21418983da7cda0e24b78bea5324f548846fa03773087de30465b2aa039e21e35adf163b6c1123d4e530e8201f341be1f0fd0a3d9cadf1a2ccd27c26ab"
+        },
+        {
+          name  = "DB_NAME"
+          value = "hotelworkdb"
+        },
+        {
+          name  = "DB_USERNAME"
+          value = "admin"
+        },
+        {
+          name  = "DB_PASSWORD"
+          value = "adminpassword123"
+        },
+        {
+          name  = "DB_HOST"
+          value = "hotel-de-work-db.cqkb4g4mwq27.ap-northeast-1.rds.amazonaws.com"
+        },
+        {
+          name  = "DB_PORT"
+          value = "3306"
+        },
+        {
+          name  = "RAILS_ENV"
+          value = "production"
+        }
+      ]
+    }
+  ])
+}

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,15 @@
+project_name       = "hotel-de-work"
+environment        = "production"
+vpc_cidr_block     = "10.0.0.0/16"
+region             = "ap-northeast-1"
+ecr_repository_url = "572902360514.dkr.ecr.ap-northeast-1.amazonaws.com/hotel-de-work-web-admin"
+container_port     = 3000
+desired_count      = 1
+vpc_id             = "vpc-8d4751ea"
+
+# terraform.tfvars からこれを削除
+#subnet_ids = [
+#  "subnet-8e3dedc6",
+#  "subnet-55393b0e",
+#  "subnet-780dd653"
+#]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,63 @@
+variable "project_name" {
+  type        = string
+  description = "Project name"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment (e.g., production, staging)"
+}
+
+variable "vpc_cidr_block" {
+  type        = string
+  description = "CIDR block for the VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr_a" {
+  type        = string
+  description = "CIDR block for public subnet A"
+  default     = "10.0.1.0/24"
+}
+
+variable "public_subnet_cidr_b" {
+  type        = string
+  description = "CIDR block for public subnet B"
+  default     = "10.0.2.0/24"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+  default     = "ap-northeast-1"
+}
+
+variable "ecr_repository_url" {
+  type        = string
+  description = "URL of the ECR image (e.g., 123456789.dkr.ecr.ap-northeast-1.amazonaws.com/your-repo)"
+}
+
+variable "container_port" {
+  type        = number
+  description = "Port number for the container"
+  default     = 3000
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Number of tasks to run"
+  default     = 1
+}
+
+variable "db_username" {
+  default = "admin"
+}
+
+variable "db_password" {
+  default = "adminpassword123"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC to use"
+  type        = string
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.3.0"
+}


### PR DESCRIPTION
ホテルデワークの Terraform を雛形として移植

.terraform/, terraform.tfstate*, tfplan は除外

terraform.tfvars を terraform.tfvars.example に変更

ここではバックエンド（S3/DynamoDB）は未設定／別PRで対応予定